### PR TITLE
fix: Limit diagnostics output on non indexed scan to a maximum number…

### DIFF
--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -162,7 +162,6 @@ pub fn scan_with_index_parallel(
     if let Some(max) = cfg.output.max_results {
         diags.truncate(max as usize);
     }
-
-    // Flatten
+  
     Ok(diags)
 }


### PR DESCRIPTION
… of results based on configuration #