### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ecpeter23/nyx/security/code-scanning/2](https://github.com/ecpeter23/nyx/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly define the permissions required for the workflow, limiting the `GITHUB_TOKEN` to read-only access for repository contents. Since the workflow does not perform any write operations, the `contents: read` permission is sufficient.

The changes will be made to the `.github/workflows/ci.yml` file. Specifically:
1. Add a `permissions` block at the root level, immediately after the `name` field.
2. Set `contents: read` as the permission.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
