### PR TITLE
fix(labels): treat web handler first param as taint source

### DIFF
--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -893,6 +893,38 @@ fn extract_param_names<'a>(func_node: Node<'a>, lang: &str, code: &'a [u8]) -> V
     names
 }
 
+/// Index of the parameter that should be treated as a taint source because
+/// the function looks like a web framework request handler.
+///
+/// Currently scoped narrowly to JavaScript/TypeScript Express/Koa-style
+/// signatures: `(req, res, ...)`, `(request, response, ...)`, or `(ctx, ...)`.
+/// Detection mirrors the name-based heuristic in
+/// `cfg_analysis::auth::has_web_handler_params` (kept separate because cfg.rs
+/// runs before cfg_analysis can import it).
+fn web_handler_source_param_index(lang: &str, param_names: &[String]) -> Option<usize> {
+    if !matches!(lang, "javascript" | "typescript") {
+        return None;
+    }
+
+    let is_req = |p: &String| {
+        let l = p.to_ascii_lowercase();
+        l == "req" || l == "request"
+    };
+    let is_res = |p: &String| {
+        let l = p.to_ascii_lowercase();
+        l == "res" || l == "response"
+    };
+    let req_idx = param_names.iter().position(is_req);
+    if req_idx.is_some() && param_names.iter().any(is_res) {
+        return req_idx;
+    }
+
+    // Koa: leading `ctx` (often `(ctx, next)`).
+    param_names
+        .iter()
+        .position(|p| p.eq_ignore_ascii_case("ctx"))
+}
+
 /// Check if a callee name matches any configured terminator.
 fn is_configured_terminator(callee: &str, analysis_rules: Option<&LangAnalysisRules>) -> bool {
     if let Some(rules) = analysis_rules {
@@ -1331,6 +1363,32 @@ fn build_sub<'a>(
             let param_names = extract_param_names(ast, lang, code);
             let param_count = param_names.len();
 
+            // 1c) Seed a synthetic Source node for the request parameter of
+            // recognised web-framework handlers, so taint sees the request
+            // object as user input even without an explicit `req.body` read.
+            let body_pred = match web_handler_source_param_index(lang, &param_names)
+                .and_then(|i| param_names.get(i))
+            {
+                Some(name) => {
+                    let seed_idx = g.add_node(NodeInfo {
+                        kind: StmtKind::Seq,
+                        span: (ast.start_byte(), ast.end_byte()),
+                        label: Some(DataLabel::Source(Cap::all())),
+                        defines: Some(name.clone()),
+                        uses: Vec::new(),
+                        callee: Some(name.clone()),
+                        enclosing_func: Some(fn_name.clone()),
+                        call_ordinal: 0,
+                        condition_text: None,
+                        condition_vars: Vec::new(),
+                        condition_negated: false,
+                    });
+                    connect_all(g, &[entry_idx], seed_idx, EdgeKind::Seq);
+                    seed_idx
+                }
+                None => entry_idx,
+            };
+
             // 2) build its body with a fresh call ordinal counter for this function scope
             // Snapshot the current node count so we can iterate only over nodes
             // created within this function (avoids O(N²) scan of the full graph).
@@ -1354,7 +1412,7 @@ fn build_sub<'a>(
             let mut fn_continues = Vec::new();
             let body_exits = build_sub(
                 body,
-                &[entry_idx],
+                &[body_pred],
                 g,
                 lang,
                 code,


### PR DESCRIPTION
## Summary

- Seed a synthetic `Source(Cap::all())` CFG node for the request parameter of
  recognised Express/Koa-style JS/TS handlers (`(req|request, res|response, ...)`
  or leading `(ctx, ...)`), so taint catches calls that forward the request
  object itself (e.g. `exec(req)`) rather than only property reads like
  `req.body` or `req.query.x`.
- Scope is intentionally narrow: only JS/TS, only well-known framework
  signatures. Detection mirrors `cfg_analysis::auth::has_web_handler_params`.

## Fixture promotions

None. The work-unit candidate fixtures (`switch_fallthrough.js`,
`decorator_handler.ts`, `enum_switch.ts`, `generic_handler.ts`,
`sqli_concat.js`) all use non-Express signatures
(`handleAction(action, userInput)`, `executeCommand(input)`,
`getUser(connection, userId)`, etc.), so the Express-only fix does not
light them up. Per the unit instructions ("Only promote fixtures whose
findings actually light up; leave others soft if they don't"), their
`must_match:false` entries remain unchanged. A broader "handler-style
function-name" heuristic was considered but would risk corpus-wide
over-tainting without clear FP bounds within this unit's scope.

## Baseline / corpus impact

- Baseline (release/0.5.0 HEAD): `237 matched, 0 hard failures, 99 soft misses, 267 unexpected`
- After change: `237 matched, 0 hard failures, 99 soft misses, 267 unexpected`
- No change in unexpected count. The new behaviour only fires on Express
  signatures where the request object is used directly, which no existing
  fixture exercises.
- Smoke test: `function handler(req, res) { eval(req); }` now emits
  `taint-unsanitised-flow` (source=req → sink=eval). A non-handler
  `function handler(userInput, config) { eval(userInput); }` does not
  receive the source label.

## Harness note

The harness at `release/0.5.0` HEAD does not include `must_not_match` or
"forbidden violations" in its RESULTS line; the working schema is
`rule_id, severity, must_match, line_range, evidence_contains, notes`.
No harness changes made.

## Test plan

- [x] `cargo build --tests`
- [x] `cargo test --lib` — 323 passed
- [x] `cargo test --test real_world_tests` — 0 hard failures
- [x] `cargo test --test integration_tests --test pattern_tests --test state_tests --test taint_termination_test` — all pass
- [x] Smoke: Express-style `(req, res) { eval(req) }` → taint finding; non-handler → no taint finding

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>